### PR TITLE
feat(sec-touch): add sniffer component and prioritize SET tasks in the queue

### DIFF
--- a/.specs/sniffer.md
+++ b/.specs/sniffer.md
@@ -99,4 +99,4 @@ Note: discovered state is held in RAM only. After a device restart or firmware f
 2. Turning scan mode on stops normal polling and listener updates; the text sensor populates with discovered IDs across the configured range.
 3. Turning scan mode off mid-scan resumes normal polling immediately; the saved position is used when scan mode is turned on again.
 4. When scan mode runs to completion, polling resumes automatically and the binary sensor reflects the off state.
-5. IDs with registered listeners do not appear in passive capture output, but do appear in scan mode output.
+5. IDs with registered listeners do not appear in passive capture output and are skipped in scan mode, so they do not appear in scan output either.  

--- a/.specs/sniffer.md
+++ b/.specs/sniffer.md
@@ -1,0 +1,102 @@
+# Sniffer / Listener Mode
+
+## Goal
+
+Discover and capture UART messages sent by the hardware device for property IDs that have no registered listener, so unknown properties can be identified and mapped for future use.
+
+---
+
+## Behaviour
+
+### Passive capture
+
+When a message arrives for a property ID that no component has registered interest in, it is captured and recorded. Registered components (e.g. fan controls) are unaffected and continue to work normally.
+
+### Active scan mode
+
+An optional mode that can be toggled on and off by the user.
+
+**When turned on:**
+- Regular polling stops completely. Any tasks that were already queued (e.g. pending fan SET commands) are discarded at this point.
+- Registered component listeners stop receiving updates.
+- The sniffer iterates through a configured range of property IDs, querying them one at a time. The next query is only issued after a response (or timeout) for the previous one has been processed.
+- Property IDs that already have registered listeners are silently skipped — they are not queried and do not appear in the output.
+
+**When turned off:**
+- Scanning stops immediately. The last queried ID is saved.
+- Regular polling resumes at once, without waiting for the next scheduled poll cycle.
+
+**Resume behaviour:** turning scan mode back on continues from the saved position. If the previous scan completed the full range, the next run restarts from the beginning.
+
+---
+
+## Recorded data
+
+For each discovered property ID the sniffer stores:
+- The property ID.
+- The command type of the message (so responses to read requests can be distinguished from write notifications).
+- The last seen value.
+- The timestamp of the last update.
+
+The timestamp uses the real-time clock when available; otherwise it falls back to device uptime.
+
+---
+
+## Outputs
+
+- **Text sensor**: publishes the recorded entries as a comma-separated string in `id=value` format (e.g. `1=23, 2=13, 5=100`). The command type and timestamp are omitted from the sensor value but are still logged at `[I]` level for every discovery.
+  - **During active scan**: the sensor is not updated while the scan is running. A single publish happens when the scan finishes (normally or when manually stopped mid-scan).
+  - **In passive mode**: the sensor is updated on every new or changed entry, as before.
+  - Duplicate messages that carry no new information never trigger a publish. The output is capped at 2048 characters (`MAX_STATE_LEN` in `sec_touch_sniffer.h`); entries beyond the cap are replaced with `...`.
+- **Switch** (optional): reflects whether scan mode is currently active and can be toggled from Home Assistant.
+
+---
+
+## Configuration
+
+- The scan range (start and end ID) is configurable. `scan_start` must be ≤ `scan_end`; an invalid range is rejected at config validation time. If no range is configured, active scan mode is disabled and only passive capture is available.
+- The real-time clock source is optional.
+- The switch for scan state is optional.
+
+---
+
+## User interaction
+
+A toggle switch switches scan mode on or off. No other interaction is required; the sniffer advances through IDs automatically and exits scan mode on its own when the range is exhausted.
+
+---
+
+## Implementation notes
+
+### GET response protocol
+The SEC-Touch device responds to a GET request with two separate messages:
+1. `[STX][ACK][ETX]` — confirms receipt of the request
+2. `[STX]32[TAB]property_id[TAB]value[TAB]crc[ETX]` — the actual data
+
+For unknown or unsupported property IDs the device sends `[STX][NAK][ETX]` instead of the data message. The component treats NAK as a failed task and advances the scan to the next ID.
+
+Some property values are space-padded to a fixed width (e.g. `"00               "`). This makes the data message longer than the typical case and may cause it to arrive split across multiple UART read cycles. The `loop()` function handles this by buffering partial messages across calls and only processing once ETX is received.
+
+The component keeps the task in `GET_DATA` state after receiving the ACK so that the queue-empty callback (which drives scan advancement) cannot fire before the data/NAK message arrives.
+
+### Scan timeout and retry
+When a scan task receives no response within `TASK_TIMEOUT_MS` (2 s), the watchdog fires and the sniffer waits **5 seconds** before retrying that property ID once. If the retry also times out, the ID is logged as unresponsive and the scan advances to the next one immediately (no further wait).
+
+The watchdog check runs regardless of whether the task queue is empty. Tasks are popped from the queue when dispatched, so the queue is empty while waiting for a response — the check must happen unconditionally in `loop()`, not inside the queue-empty guard.
+
+If the user stops the scan during the 5-second retry wait, the pending retry is cancelled and normal polling resumes immediately.
+
+### Text sensor state and MQTT
+The text sensor publishes a compact `id=value` list on scan completion (or manual stop). With a full scan (200+ IDs) the state string can exceed 1600 characters. If MQTT is used instead of the native API, the broker's `max_packet_size` must be set to at least 4096 bytes — Mosquitto defaults to 256 bytes and will silently drop larger publishes, causing HA to show "unknown". The ESPHome native API has no such limit.
+
+Note: discovered state is held in RAM only. After a device restart or firmware flash the state is lost and the scan must be re-run.
+
+### Memory on constrained hardware
+`discovered_ids_` is an `std::map` that grows with the number of responsive property IDs found. Each entry takes ~80–100 bytes on the heap (red-black tree node + `SniffedEntry`). A scan that discovers 200 IDs uses roughly 20 KB — safe on ESP32 (~300 KB free heap) but **not recommended on ESP8266** (~40 KB usable heap). Keep scan ranges very modest on ESP8266, or avoid active scan entirely.
+
+
+1. With scan mode disabled, captured unknown IDs appear in the text sensor output and do not interfere with existing controls.
+2. Turning scan mode on stops normal polling and listener updates; the text sensor populates with discovered IDs across the configured range.
+3. Turning scan mode off mid-scan resumes normal polling immediately; the saved position is used when scan mode is turned on again.
+4. When scan mode runs to completion, polling resumes automatically and the binary sensor reflects the off state.
+5. IDs with registered listeners do not appear in passive capture output, but do appear in scan mode output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# ESPHome Components — Development Guidelines
+
+## C++ brace style
+
+Always wrap `if`/`else`/`for`/`while` bodies in braces `{}`, even single-line bodies. Never use brace-free single-line control flow.
+
+## Early exit
+
+Always exit early when a condition makes the rest of a function irrelevant. Check preconditions and guard clauses at the top and return immediately. Avoid wrapping the main logic in an `if` block when an inverted early return keeps the happy path at the lowest indentation level.

--- a/components/sec_touch/__init__.py
+++ b/components/sec_touch/__init__.py
@@ -15,11 +15,13 @@ FAN_LABEL_IDS = (78, 79, 80, 81, 82, 83)
 
 
 CONF_SEC_TOUCH_ID = "sec_touch_id"
+CONF_INTER_TASK_DELAY = "inter_task_delay_ms"
 # The total of fan pairs that the SEC-Touch shows in the screen
 
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(SECTouchComponent),
+        cv.Optional(CONF_INTER_TASK_DELAY, default=30): cv.positive_int,
     }
 )
 
@@ -44,3 +46,4 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+    cg.add(var.set_inter_task_delay(config[CONF_INTER_TASK_DELAY]))

--- a/components/sec_touch/_definitions.h
+++ b/components/sec_touch/_definitions.h
@@ -101,6 +101,14 @@ constexpr const char *NAME_MAPPING[NAME_MAPPING_COUNT] = {
  */
 using UpdateCallbackListener = std::function<void(int property_id, int new_value)>;
 
+// Includes command_id so the sniffer can record whether the device message was
+// a data response (command_id=32) or, if the hardware ever sends unsolicited messages
+// with a different command_id, distinguish those as well.
+using RawMessageCallbackListener = std::function<void(int command_id, int property_id, int new_value)>;
+
+// Called when the task queue is empty and no task is awaiting a response
+using QueueEmptyListener = std::function<void()>;
+
 // Helper function to check if an ID is in the array
 template<typename T, size_t N> static bool contains(const std::array<T, N> &arr, int value) {
   return std::find(arr.begin(), arr.end(), value) != arr.end();
@@ -157,7 +165,7 @@ struct IncomingMessage {
 
  public:
   char buffer[64];
-  size_t buffer_index = -1;
+  int buffer_index = -1;
 
   void reset() {
     this->buffer_index = -1;
@@ -193,7 +201,7 @@ struct IncomingMessage {
    * @returns the index of the last byte stored in the buffer
    */
   int store_data(uint8_t data) {
-    if (this->buffer_index + 1 < sizeof(this->buffer) - 1) {
+    if (this->buffer_index + 1 < (int) sizeof(this->buffer) - 1) {
       this->buffer_index++;
       this->buffer[this->buffer_index] = data;
 
@@ -241,6 +249,11 @@ struct GetDataTask : public BaseTask {
       return std::unique_ptr<GetDataTask>(new GetDataTask(targetType, property_id));  // Valid task
     }
     return nullptr;  // Null unique_ptr if validation fails
+  }
+
+  // Bypasses ID validation — for sniffer/discovery use only
+  static std::unique_ptr<GetDataTask> create_unchecked(int property_id) {
+    return std::unique_ptr<GetDataTask>(new GetDataTask(TaskTargetType::LEVEL, property_id));
   }
 
   TaskType get_task_type() const override { return TaskType::GET_DATA; }

--- a/components/sec_touch/readme.md
+++ b/components/sec_touch/readme.md
@@ -245,6 +245,275 @@ Notice that the fans numbers are ordered so:
 | Pair 2 | Pair 4 | Pair 6 | ⚙️  |
 
 
+## Sniffer
+
+The sniffer listens for UART messages sent by the SEC-Touch for property IDs that no component has registered interest in. This lets you discover unknown property IDs for future use.
+
+Two modes are available:
+
+- **Passive** (always on): unknown IDs that arrive during normal polling are captured automatically.
+- **Active scan** (optional): iterates through a configured range of property IDs, querying each one in turn. Normal polling is paused while scanning.
+
+Results are published as a text sensor and visible in Home Assistant. An optional switch reflects whether a scan is currently running and can be toggled from Home Assistant.
+
+> **Note:** Active scan is not recommended on ESP8266. Each discovered entry uses ~80–100 bytes of heap; a 200-ID scan uses ~20 KB against only ~40 KB of usable heap.
+
+### Passive-only example
+
+```yaml
+text_sensor:
+  - platform: sec_touch_sniffer
+    sec_touch_id: sec_touch_component
+    name: "Sniffer"
+```
+
+### Full example (with active scan)
+
+```yaml
+time:
+  - platform: homeassistant
+    id: ha_time
+
+text_sensor:
+  - platform: sec_touch_sniffer
+    sec_touch_id: sec_touch_component
+    name: "Sniffer"
+    time_id: ha_time       # optional — uses device uptime when omitted
+    scan_start: 1          # first property ID to query in active scan
+    scan_end: 250          # last property ID to query; must be >= scan_start
+    scan_switch:
+      name: "Sniffer Scan Active"
+```
+
+Turning the switch on starts a scan from `scan_start`. Turning it off stops the scan immediately, publishes the results discovered so far, and saves the current position. Turning it on again resumes from where it left off. When the full range has been scanned, polling resumes automatically, the full result is published to the text sensor, and the switch turns off.
+
+If a property ID does not respond within 2 seconds the scan retries it once. If it times out again the ID is skipped and a warning is logged.
+
+### What I have found so far
+
+Scan performed over IDs 1–208. IDs 78–83 (fan labels) and 173–178 (fan levels) are registered listeners and are excluded from the sniffer output — their meaning is already documented above.
+
+**If you recognize a pattern or know what an ID controls, please open a PR or issue.**
+
+<details>
+<summary>Raw sniffer output (copy-paste ready)</summary>
+
+```
+1=23, 2=16, 3=0, 4=0, 5=100, 6=1, 7=1, 8=1, 9=0, 10=0, 11=0, 12=0, 13=0, 14=0, 15=0, 16=0, 17=0, 18=0, 19=80, 20=6, 21=16, 22=40, 23=32, 24=28, 25=25, 26=21, 27=0, 28=61, 29=70, 30=74, 31=77, 32=81, 33=100, 34=50, 35=50, 36=50, 37=50, 38=50, 39=50, 40=50, 41=50, 42=50, 43=50, 44=50, 45=50, 46=50, 47=75, 48=800, 49=1200, 50=400, 51=20, 52=70, 53=10, 54=20, 55=0, 56=127, 57=0, 58=1, 59=95, 60=1, 61=1, 62=1, 63=1, 64=1, 65=0, 66=1, 67=2, 68=3, 69=4, 70=5, 71=6, 72=0, 73=1, 74=1, 75=1, 76=1, 77=1, 83=0, 84=13, 85=0, 86=1, 87=0, 88=0, 89=0, 90=0, 91=0, 92=100, 93=74, 94=6, 95=0, 96=100, 97=250, 98=2000, 99=-50, 100=50, 101=18, 102=6, 103=11, 104=22, 105=9, 106=22, 107=0, 108=7, 109=4, 110=3, 111=0, 112=18, 113=13, 114=14, 115=7, 116=23, 117=7, 118=7, 119=0, 120=7, 121=2, 122=0, 123=0, 124=13, 125=14, 126=22, 127=4, 128=12, 129=7, 130=0, 131=1, 132=0, 133=0, 134=0, 135=13, 136=14, 137=20, 138=8, 139=12, 140=7, 141=0, 142=2, 143=0, 144=0, 145=0, 146=0, 147=23, 148=8, 149=15, 150=4, 151=7, 152=1, 153=1, 154=0, 155=7, 156=0, 157=6, 158=9, 159=15, 160=20, 161=22, 162=0, 163=0, 164=0, 165=0, 166=0, 167=0, 168=3, 169=0, 170=0, 171=0, 172=0, 176=0, 178=255, 179=127, 180=127, 181=127, 182=127, 183=127, 184=127, 185=36, 186=31, 187=27, 188=18, 189=10, 190=0, 191=64, 192=70, 194=85, 195=100, 196=0, 197=36, 198=31, 199=27, 200=23, 201=18, 202=10, 203=64, 204=70, 205=74, 206=80, 207=85, 208=100
+```
+
+</details>
+
+<details>
+<summary>ID analysis table (help wanted — fill in what you know)</summary>
+
+> **IDs not in output:** 78–82 (fan pair labels, registered listener), 173–175, 177 (fan pair levels, registered listener), 193 (no response from device).
+
+| ID | Value | Hypothesis | Confidence |
+|----|-------|------------|------------|
+| 1 | 23 | | |
+| 2 | 16 | | |
+| 3 | 0 | | |
+| 4 | 0 | | |
+| 5 | 100 | | |
+| 6 | 1 | | |
+| 7 | 1 | | |
+| 8 | 1 | | |
+| 9 | 0 | | |
+| 10 | 0 | | |
+| 11 | 0 | | |
+| 12 | 0 | | |
+| 13 | 0 | | |
+| 14 | 0 | | |
+| 15 | 0 | | |
+| 16 | 0 | | |
+| 17 | 0 | | |
+| 18 | 0 | | |
+| 19 | 80 | | |
+| 20 | 6 | | |
+| 21 | 16 | | |
+| 22 | 40 | | |
+| 23 | 32 | | |
+| 24 | 28 | | |
+| 25 | 25 | | |
+| 26 | 21 | | |
+| 27 | 0 | | |
+| 28 | 61 | | |
+| 29 | 70 | | |
+| 30 | 74 | | |
+| 31 | 77 | | |
+| 32 | 81 | | |
+| 33 | 100 | | |
+| 34 | 50 | | |
+| 35 | 50 | | |
+| 36 | 50 | | |
+| 37 | 50 | | |
+| 38 | 50 | | |
+| 39 | 50 | | |
+| 40 | 50 | | |
+| 41 | 50 | | |
+| 42 | 50 | | |
+| 43 | 50 | | |
+| 44 | 50 | | |
+| 45 | 50 | | |
+| 46 | 50 | | |
+| 47 | 75 | | |
+| 48 | 800 | | |
+| 49 | 1200 | | |
+| 50 | 400 | | |
+| 51 | 20 | | |
+| 52 | 70 | | |
+| 53 | 10 | | |
+| 54 | 20 | | |
+| 55 | 0 | | |
+| 56 | 127 | | |
+| 57 | 0 | | |
+| 58 | 1 | | |
+| 59 | 95 | | |
+| 60 | 1 | | |
+| 61 | 1 | | |
+| 62 | 1 | | |
+| 63 | 1 | | |
+| 64 | 1 | | |
+| 65 | 0 | | |
+| 66 | 1 | | |
+| 67 | 2 | | |
+| 68 | 3 | | |
+| 69 | 4 | | |
+| 70 | 5 | | |
+| 71 | 6 | | |
+| 72 | 0 | | |
+| 73 | 1 | | |
+| 74 | 1 | | |
+| 75 | 1 | | |
+| 76 | 1 | | |
+| 77 | 1 | | |
+| 83 | 0 | | |
+| 84 | 13 | | |
+| 85 | 0 | | |
+| 86 | 1 | | |
+| 87 | 0 | | |
+| 88 | 0 | | |
+| 89 | 0 | | |
+| 90 | 0 | | |
+| 91 | 0 | | |
+| 92 | 100 | | |
+| 93 | 74 | | |
+| 94 | 6 | | |
+| 95 | 0 | | |
+| 96 | 100 | | |
+| 97 | 250 | | |
+| 98 | 2000 | | |
+| 99 | -50 | | |
+| 100 | 50 | | |
+| 101 | 18 | | |
+| 102 | 6 | | |
+| 103 | 11 | | |
+| 104 | 22 | | |
+| 105 | 9 | | |
+| 106 | 22 | | |
+| 107 | 0 | | |
+| 108 | 7 | | |
+| 109 | 4 | | |
+| 110 | 3 | | |
+| 111 | 0 | | |
+| 112 | 18 | | |
+| 113 | 13 | | |
+| 114 | 14 | | |
+| 115 | 7 | | |
+| 116 | 23 | | |
+| 117 | 7 | | |
+| 118 | 7 | | |
+| 119 | 0 | | |
+| 120 | 7 | | |
+| 121 | 2 | | |
+| 122 | 0 | | |
+| 123 | 0 | | |
+| 124 | 13 | | |
+| 125 | 14 | | |
+| 126 | 22 | | |
+| 127 | 4 | | |
+| 128 | 12 | | |
+| 129 | 7 | | |
+| 130 | 0 | | |
+| 131 | 1 | | |
+| 132 | 0 | | |
+| 133 | 0 | | |
+| 134 | 0 | | |
+| 135 | 13 | | |
+| 136 | 14 | | |
+| 137 | 20 | | |
+| 138 | 8 | | |
+| 139 | 12 | | |
+| 140 | 7 | | |
+| 141 | 0 | | |
+| 142 | 2 | | |
+| 143 | 0 | | |
+| 144 | 0 | | |
+| 145 | 0 | | |
+| 146 | 0 | | |
+| 147 | 23 | | |
+| 148 | 8 | | |
+| 149 | 15 | | |
+| 150 | 4 | | |
+| 151 | 7 | | |
+| 152 | 1 | | |
+| 153 | 1 | | |
+| 154 | 0 | | |
+| 155 | 7 | | |
+| 156 | 0 | | |
+| 157 | 6 | | |
+| 158 | 9 | | |
+| 159 | 15 | | |
+| 160 | 20 | | |
+| 161 | 22 | | |
+| 162 | 0 | | |
+| 163 | 0 | | |
+| 164 | 0 | | |
+| 165 | 0 | | |
+| 166 | 0 | | |
+| 167 | 0 | | |
+| 168 | 3 | | |
+| 169 | 0 | | |
+| 170 | 0 | | |
+| 171 | 0 | | |
+| 172 | 0 | | |
+| 176 | 0 | | |
+| 178 | 255 | | |
+| 179 | 127 | | |
+| 180 | 127 | | |
+| 181 | 127 | | |
+| 182 | 127 | | |
+| 183 | 127 | | |
+| 184 | 127 | | |
+| 185 | 36 | | |
+| 186 | 31 | | |
+| 187 | 27 | | |
+| 188 | 18 | | |
+| 189 | 10 | | |
+| 190 | 0 | | |
+| 191 | 64 | | |
+| 192 | 70 | | |
+| 194 | 85 | | |
+| 195 | 100 | | |
+| 196 | 0 | | |
+| 197 | 36 | | |
+| 198 | 31 | | |
+| 199 | 27 | | |
+| 200 | 23 | | |
+| 201 | 18 | | |
+| 202 | 10 | | |
+| 203 | 64 | | |
+| 204 | 70 | | |
+| 205 | 74 | | |
+| 206 | 80 | | |
+| 207 | 85 | | |
+| 208 | 100 | | |
+
+</details>
+
+---
+
 ## :bulb: Setting The Fan Level above 6
 Please check the [Special Fan level Values](#fan-pair-level-special-values) section to understand the special values for the fan level.
 

--- a/components/sec_touch/sec_touch.cpp
+++ b/components/sec_touch/sec_touch.cpp
@@ -71,8 +71,8 @@ void SECTouchComponent::loop() {
                               (uint8_t) this->incoming_message.buffer[i]);
         }
         ESP_LOGW(TAG, "[watchdog] Task of type %s for property_id %d timed out — partial buffer (%d bytes: %s)",
-                 EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_,
-                 plen, hex_buf);
+                 EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_, plen,
+                 hex_buf);
       } else {
         ESP_LOGW(TAG, "[watchdog] Task of type %s for property_id %d timed out — no response received",
                  EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_);
@@ -126,8 +126,7 @@ void SECTouchComponent::loop() {
   }
 
   if (!got_etx) {
-    ESP_LOGD(TAG, "  Partial message in buffer (%d bytes), waiting for more",
-             this->incoming_message.buffer_index + 1);
+    ESP_LOGD(TAG, "  Partial message in buffer (%d bytes), waiting for more", this->incoming_message.buffer_index + 1);
     return;
   }
 
@@ -298,8 +297,14 @@ void SECTouchComponent::exit_scan_mode() {
 }
 
 void SECTouchComponent::add_set_task(std::unique_ptr<SetDataTask> task) {
-  ESP_LOGD(TAG, "add_set_task");
-  this->data_task_queue.push_back(std::move(task));
+  auto it = this->data_task_queue.begin();
+  while (it != this->data_task_queue.end() && (*it)->get_task_type() == TaskType::SET_DATA) {
+    ++it;
+  }
+  ESP_LOGD(TAG, "add_set_task: inserting at priority position %d of %d", (int) (it - this->data_task_queue.begin()),
+           (int) this->data_task_queue.size());
+
+  this->data_task_queue.insert(it, std::move(task));
 
   // WARNING: Do not add get tasks to update here. For now, we will just wait for the usual update cycle
   // if you add a get task here a recursive loop will be created (TODO?)
@@ -392,11 +397,14 @@ where:
   // Defensive: ensure message starts with STX and ends with ETX
   if (len < 7 || static_cast<uint8_t>(buf[0]) != STX || static_cast<uint8_t>(buf[len - 1]) != ETX) {
     char hex_buf[128];
+    hex_buf[0] = '\0';
     int hex_pos = 0;
     for (int i = 0; i < len && hex_pos < (int) sizeof(hex_buf) - 4; i++) {
       hex_pos += snprintf(hex_buf + hex_pos, sizeof(hex_buf) - hex_pos, "%02X ", (uint8_t) buf[i]);
     }
-    ESP_LOGE(TAG_UART, "  [process_data] Invalid message format (len=%d hex: %s). Task Failed", len, hex_buf);
+    ESP_LOGE(TAG_UART, "  [process_data] Invalid message format (task=%s property_id=%d len=%d hex: %s). Task Failed",
+             EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_, len,
+             hex_buf);
     this->cleanup_after_task_complete(true);
     return;
   }
@@ -416,13 +424,14 @@ where:
   }
   if (tab1 == -1 || tab2 == -1 || tab3 == -1) {
     char hex_buf[128];
+    hex_buf[0] = '\0';
     int hex_pos = 0;
     for (int i = 0; i < len && hex_pos < (int) sizeof(hex_buf) - 4; i++) {
       hex_pos += snprintf(hex_buf + hex_pos, sizeof(hex_buf) - hex_pos, "%02X ", (uint8_t) buf[i]);
     }
-    ESP_LOGE(TAG_UART, "  [process_data] Not enough TABs in message (task=%s property_id=%d len=%d hex: %s). Task Failed",
-             EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_, len,
-             hex_buf);
+    ESP_LOGE(
+        TAG_UART, "  [process_data] Not enough TABs in message (task=%s property_id=%d len=%d hex: %s). Task Failed",
+        EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_, len, hex_buf);
     this->cleanup_after_task_complete(true);
     return;
   }

--- a/components/sec_touch/sec_touch.cpp
+++ b/components/sec_touch/sec_touch.cpp
@@ -42,6 +42,9 @@ void SECTouchComponent::dump_config() {
 
 // poll component update
 void SECTouchComponent::update() {
+  if (this->scan_mode_active_) {
+    return;
+  }
   if (this->data_task_queue.empty() && !this->available()) {
     ESP_LOGD(TAG, "SEC-Touch update");
     this->add_recursive_tasks_to_get_queue();
@@ -51,22 +54,29 @@ void SECTouchComponent::update() {
 void SECTouchComponent::loop() {
   if (!this->available()) {
     ESP_LOGVV(TAG, "[loop] No Data available");
-    if (this->data_task_queue.empty()) {
-      return;
-    }
 
-    // Watchdog check
+    // Watchdog check: must run even when queue is empty because tasks are popped on dispatch.
     if (this->current_running_task_type != TaskType::NONE) {
-      if (this->task_start_time_ > 0 && millis() - this->task_start_time_ > TASK_TIMEOUT_MS) {
-        ESP_LOGW(TAG, "[watchdog] Task of type %s timed out, forcing cleanup",
-                 EnumToString::TaskType(this->current_running_task_type));
-        this->cleanup_after_task_complete(true);
-      } else {
+      if (this->task_start_time_ == 0 || millis() - this->task_start_time_ <= TASK_TIMEOUT_MS) {
         ESP_LOGD(TAG, "[loop] We are waiting for the response after a task of type %s",
                  EnumToString::TaskType(this->current_running_task_type));
         return;
       }
+      ESP_LOGW(TAG, "[watchdog] Task of type %s for property_id %d timed out, forcing cleanup",
+               EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_);
+      this->cleanup_after_task_complete(true, true);
     }
+
+    if (this->data_task_queue.empty()) {
+      if (!this->queue_was_idle_) {
+        this->queue_was_idle_ = true;
+        for (auto &cb : this->queue_empty_listeners) {
+          cb();
+        }
+      }
+      return;
+    }
+
     ESP_LOGD(TAG, "[loop] No Data available, processing task queue");
     this->process_task_queue();
     return;
@@ -74,45 +84,38 @@ void SECTouchComponent::loop() {
 
   ESP_LOGD(TAG, "[loop] Data available (Current buffer size: %d, Task queue size: %d)",
            this->incoming_message.buffer_index + 1, this->data_task_queue.size());
-  // We have send some data and now we are waiting for the response
+
   uint8_t peakedData;
   this->peek_byte(&peakedData);
 
-  // Noise or Heartbeat handling?
+  // Discard noise only when not already mid-message
   if (this->incoming_message.buffer_index == -1 && peakedData != STX) {
     ESP_LOGD(TAG, "[loop]  Discarding noise byte (or maybe a Heartbeat with %d?)", peakedData);
     this->read_byte(&peakedData);
     return;
   }
 
-  if (this->incoming_message.buffer_index == -1) {
-    if (peakedData != STX) {
-      ESP_LOGW(TAG, "  Discarding noise(?) byte %d, expected STX", peakedData);
-      this->read_byte(&peakedData);  // Discard the noise
-      return;
+  // Read bytes until ETX or UART buffer empties. Handles both starting a new
+  // message and continuing a partial message that spanned multiple loop() calls.
+  bool got_etx = false;
+  while (this->available()) {
+    uint8_t data;
+    this->read_byte(&data);
+    this->store_data_to_incoming_message(data);
+    if (data == ETX) {
+      ESP_LOGD(TAG, "  Received ETX, processing message");
+      got_etx = true;
+      break;
     }
+  }
 
-    ESP_LOGD(TAG, "  Received STX %d. Starting to store Message", peakedData);
-
-    // keep storing data in the incoming message until we reach ETX
-    while (this->available()) {
-      uint8_t data;
-      this->read_byte(&data);
-      this->store_data_to_incoming_message(data);
-
-      // if a ETX appears, then exit to process the message
-      if (data == ETX) {
-        ESP_LOGD(TAG, "  Received ETX %d, processing message", data);
-        break;
-      }
-    }
-
-    // Process the incoming message will also verify that the message format is correct
-    this->process_data_of_current_incoming_message();
+  if (!got_etx) {
+    ESP_LOGD(TAG, "  Partial message in buffer (%d bytes), waiting for more",
+             this->incoming_message.buffer_index + 1);
     return;
   }
 
-  return;
+  this->process_data_of_current_incoming_message();
 }
 
 void SECTouchComponent::register_text_sensor(int id, text_sensor::TextSensor *sensor) {
@@ -127,32 +130,38 @@ esphome::optional<text_sensor::TextSensor *> SECTouchComponent::get_text_sensor(
   return esphome::optional<text_sensor::TextSensor *>{};
 }
 
-void SECTouchComponent::notify_update_listeners(int property_id, int new_value) {
-  ESP_LOGV(TAG, "notify_update_listeners for property_id %d", property_id);
+void SECTouchComponent::notify_update_listeners(int command_id, int property_id, int new_value) {
+  ESP_LOGV(TAG, "notify_update_listeners command_id=%d property_id=%d", command_id, property_id);
 
-  auto recursive_listener = this->recursive_update_listeners.find(property_id);
-
-  if (recursive_listener == this->recursive_update_listeners.end()) {
-    ESP_LOGV(TAG, "No recursive_update_listeners found for property_id %d", property_id);
-  } else {
-    ESP_LOGV(TAG, "recursive_update_listener found for property_id %d", property_id);
-    UpdateCallbackListener &listener = recursive_listener->second;
-    listener(property_id, new_value);  // Call the listener
+  if (this->scan_mode_active_) {
+    for (auto &cb : this->raw_message_listeners) {
+      cb(command_id, property_id, new_value);
+    }
+    return;
   }
 
+  auto recursive_listener = this->recursive_update_listeners.find(property_id);
   auto manual_listener = this->manual_update_listeners.find(property_id);
 
-  if (manual_listener == this->manual_update_listeners.end()) {
-    ESP_LOGV(TAG, "No manual_update_listeners found for property_id %d", property_id);
-  } else {
+  if (recursive_listener != this->recursive_update_listeners.end()) {
+    ESP_LOGV(TAG, "recursive_update_listener found for property_id %d", property_id);
+    recursive_listener->second(property_id, new_value);
+  }
+
+  if (manual_listener != this->manual_update_listeners.end()) {
     ESP_LOGD(TAG, "manual_update_listener found for property_id %d", property_id);
-    UpdateCallbackListener &listener = manual_listener->second;
-    listener(property_id, new_value);  // Call the listener
+    manual_listener->second(property_id, new_value);
   }
 
   if (recursive_listener == this->recursive_update_listeners.end() &&
       manual_listener == this->manual_update_listeners.end()) {
-    ESP_LOGE(TAG, "No listener found for property_id %d", property_id);
+    if (this->raw_message_listeners.empty()) {
+      ESP_LOGW(TAG, "No listener for property_id %d (value %d)", property_id, new_value);
+      return;
+    }
+    for (auto &cb : this->raw_message_listeners) {
+      cb(command_id, property_id, new_value);
+    }
   }
 }
 
@@ -169,7 +178,9 @@ void SECTouchComponent::process_task_queue() {
            EnumToString::TaskType(task->get_task_type()));
 
   this->current_running_task_type = task->get_task_type();
-  this->task_start_time_ = millis();  // <-- Set watchdog timer here
+  this->task_start_time_ = millis();
+  this->current_running_task_property_id_ = task->property_id;
+  this->queue_was_idle_ = false;
 
   switch (task->get_task_type()) {
     case TaskType::SET_DATA:
@@ -193,6 +204,7 @@ int SECTouchComponent::store_data_to_incoming_message(uint8_t data) {
 void SECTouchComponent::add_recursive_tasks_to_get_queue() {
   if (this->recursive_update_ids.empty()) {
     ESP_LOGW(TAG, "No property ids are registered for recursive tasks");
+    return;
   }
 
   for (size_t i = 0; i < this->recursive_update_ids.size(); i++) {
@@ -233,9 +245,40 @@ void SECTouchComponent::register_recursive_update_listener(int property_id, Upda
 }
 
 void SECTouchComponent::register_manual_update_listener(int property_id, UpdateCallbackListener listener) {
-  ESP_LOGD(TAG, "register_recursive_update_listener for property_id %d", property_id);
-  this->manual_update_listeners[property_id] = std ::move(listener);
+  ESP_LOGD(TAG, "register_manual_update_listener for property_id %d", property_id);
+  this->manual_update_listeners[property_id] = std::move(listener);
   this->manual_update_ids.push_back(property_id);
+}
+
+void SECTouchComponent::register_raw_message_listener(RawMessageCallbackListener listener) {
+  this->raw_message_listeners.push_back(std::move(listener));
+}
+
+void SECTouchComponent::register_queue_empty_listener(QueueEmptyListener listener) {
+  this->queue_empty_listeners.push_back(std::move(listener));
+}
+
+void SECTouchComponent::add_discovery_get_task(int property_id) {
+  this->data_task_queue.push_back(GetDataTask::create_unchecked(property_id));
+}
+
+void SECTouchComponent::enter_scan_mode() {
+  ESP_LOGI(TAG, "Entering scan mode — pausing regular polling");
+  if (!this->data_task_queue.empty()) {
+    ESP_LOGW(TAG, "Entering scan mode — discarding %d pending task(s)", this->data_task_queue.size());
+  }
+  this->data_task_queue.clear();
+  this->incoming_message.reset();
+  this->current_running_task_type = TaskType::NONE;
+  this->task_start_time_ = 0;
+  this->queue_was_idle_ = false;  // Force queue-empty callback to fire so scan tasks get queued
+  this->scan_mode_active_ = true;
+}
+
+void SECTouchComponent::exit_scan_mode() {
+  ESP_LOGI(TAG, "Exiting scan mode — resuming regular polling");
+  this->scan_mode_active_ = false;
+  this->add_recursive_tasks_to_get_queue();
 }
 
 void SECTouchComponent::add_set_task(std::unique_ptr<SetDataTask> task) {
@@ -293,8 +336,22 @@ Now, we need to extract the parts of the message. It can be either:
   if (this->incoming_message.buffer[0] == STX && this->incoming_message.buffer[1] == ACK &&
       this->incoming_message.buffer[this->incoming_message.buffer_index] == ETX) {
     ESP_LOGD(TAG, "  Received ACK message");
-    // this->send_ack_message(); // I do not think we need to send ACK back here, do we?
-    this->cleanup_after_task_complete();
+    if (this->current_running_task_type == TaskType::GET_DATA) {
+      // GET: ACK confirms the device received our request; the data response follows.
+      // Keep task state so the queue-empty callback does not fire prematurely.
+      this->incoming_message.reset();
+    } else {
+      // SET: ACK is the complete response — task is done.
+      this->cleanup_after_task_complete();
+    }
+    return;
+  }
+
+  // NAK: device rejected the request (e.g. unknown property_id during scan)
+  if (this->incoming_message.buffer[0] == STX && this->incoming_message.buffer[1] == NAK &&
+      this->incoming_message.buffer[this->incoming_message.buffer_index] == ETX) {
+    ESP_LOGW(TAG, "  Received NAK — property_id not supported by device");
+    this->cleanup_after_task_complete(true);
     return;
   }
 
@@ -318,7 +375,12 @@ where:
 
   // Defensive: ensure message starts with STX and ends with ETX
   if (len < 7 || static_cast<uint8_t>(buf[0]) != STX || static_cast<uint8_t>(buf[len - 1]) != ETX) {
-    ESP_LOGE(TAG_UART, "  [process_data] Invalid message format. Task Failed");
+    char hex_buf[128];
+    int hex_pos = 0;
+    for (int i = 0; i < len && hex_pos < (int) sizeof(hex_buf) - 4; i++) {
+      hex_pos += snprintf(hex_buf + hex_pos, sizeof(hex_buf) - hex_pos, "%02X ", (uint8_t) buf[i]);
+    }
+    ESP_LOGE(TAG_UART, "  [process_data] Invalid message format (len=%d hex: %s). Task Failed", len, hex_buf);
     this->cleanup_after_task_complete(true);
     return;
   }
@@ -354,18 +416,18 @@ where:
   // Optionally: validate CRC here if needed
 
   // Notify listeners
-  this->notify_update_listeners(property_id, value);
+  this->notify_update_listeners(command_id, property_id, value);
 
-  this->incoming_message.reset();
+  this->cleanup_after_task_complete();
   this->send_ack_message();  // Send ACK back
 }
 
-void SECTouchComponent::cleanup_after_task_complete(bool failed) {
+void SECTouchComponent::cleanup_after_task_complete(bool failed, bool is_timeout) {
   ESP_LOGD(TAG, "cleanup_after_task_complete called, failed: %s", failed ? "true" : "false");
   this->incoming_message.reset();
   this->current_running_task_type = TaskType::NONE;
-  this->task_start_time_ = 0;  // <-- Reset watchdog timer
-                               // TODO: SEND NACK??
+  this->task_start_time_ = 0;
+  this->last_scan_task_timed_out_ = is_timeout && this->scan_mode_active_;
 }
 }  // namespace sec_touch
 }  // namespace esphome

--- a/components/sec_touch/sec_touch.cpp
+++ b/components/sec_touch/sec_touch.cpp
@@ -90,6 +90,9 @@ void SECTouchComponent::loop() {
       return;
     }
 
+    if (millis() < this->task_ready_at_ms_) {
+      return;
+    }
     ESP_LOGD(TAG, "[loop] No Data available, processing task queue");
     this->process_task_queue();
     return;
@@ -448,6 +451,7 @@ void SECTouchComponent::cleanup_after_task_complete(bool failed, bool is_timeout
   this->current_running_task_type = TaskType::NONE;
   this->task_start_time_ = 0;
   this->last_scan_task_timed_out_ = is_timeout && this->scan_mode_active_;
+  this->task_ready_at_ms_ = millis() + this->inter_task_delay_ms_;
 }
 }  // namespace sec_touch
 }  // namespace esphome

--- a/components/sec_touch/sec_touch.cpp
+++ b/components/sec_touch/sec_touch.cpp
@@ -62,8 +62,21 @@ void SECTouchComponent::loop() {
                  EnumToString::TaskType(this->current_running_task_type));
         return;
       }
-      ESP_LOGW(TAG, "[watchdog] Task of type %s for property_id %d timed out, forcing cleanup",
-               EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_);
+      if (this->incoming_message.buffer_index >= 0) {
+        char hex_buf[128];
+        int hex_pos = 0;
+        int plen = this->incoming_message.buffer_index + 1;
+        for (int i = 0; i < plen && hex_pos < (int) sizeof(hex_buf) - 4; i++) {
+          hex_pos += snprintf(hex_buf + hex_pos, sizeof(hex_buf) - hex_pos, "%02X ",
+                              (uint8_t) this->incoming_message.buffer[i]);
+        }
+        ESP_LOGW(TAG, "[watchdog] Task of type %s for property_id %d timed out — partial buffer (%d bytes: %s)",
+                 EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_,
+                 plen, hex_buf);
+      } else {
+        ESP_LOGW(TAG, "[watchdog] Task of type %s for property_id %d timed out — no response received",
+                 EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_);
+      }
       this->cleanup_after_task_complete(true, true);
     }
 
@@ -399,7 +412,14 @@ where:
     }
   }
   if (tab1 == -1 || tab2 == -1 || tab3 == -1) {
-    ESP_LOGE(TAG_UART, "  [process_data] Not enough TABs in message. Task Failed");
+    char hex_buf[128];
+    int hex_pos = 0;
+    for (int i = 0; i < len && hex_pos < (int) sizeof(hex_buf) - 4; i++) {
+      hex_pos += snprintf(hex_buf + hex_pos, sizeof(hex_buf) - hex_pos, "%02X ", (uint8_t) buf[i]);
+    }
+    ESP_LOGE(TAG_UART, "  [process_data] Not enough TABs in message (task=%s property_id=%d len=%d hex: %s). Task Failed",
+             EnumToString::TaskType(this->current_running_task_type), this->current_running_task_property_id_, len,
+             hex_buf);
     this->cleanup_after_task_complete(true);
     return;
   }

--- a/components/sec_touch/sec_touch.h
+++ b/components/sec_touch/sec_touch.h
@@ -35,6 +35,18 @@ class SECTouchComponent : public PollingComponent, public uart::UARTDevice {
    */
   void register_manual_update_listener(int property_id, UpdateCallbackListener listener);
 
+  void register_raw_message_listener(RawMessageCallbackListener listener);
+  void register_queue_empty_listener(QueueEmptyListener listener);
+  void add_discovery_get_task(int property_id);
+
+  void enter_scan_mode();
+  void exit_scan_mode();
+  bool get_last_scan_task_timed_out() const { return last_scan_task_timed_out_; }
+  bool is_property_registered(int property_id) const {
+    return this->recursive_update_listeners.count(property_id) > 0 ||
+           this->manual_update_listeners.count(property_id) > 0;
+  }
+
   void add_set_task(std::unique_ptr<SetDataTask> task);
   void add_recursive_tasks_to_get_queue();
   void add_manual_tasks_to_queue();
@@ -51,9 +63,14 @@ class SECTouchComponent : public PollingComponent, public uart::UARTDevice {
   std::map<int, UpdateCallbackListener> manual_update_listeners;
   std::vector<int> manual_update_ids;
 
+  std::vector<RawMessageCallbackListener> raw_message_listeners;
+  std::vector<QueueEmptyListener> queue_empty_listeners;
+  bool scan_mode_active_{false};
+  bool queue_was_idle_{false};
+
   std::map<int, text_sensor::TextSensor *> text_sensors;
 
-  void notify_update_listeners(int property_id, int new_value);
+  void notify_update_listeners(int command_id, int property_id, int new_value);
   TaskType current_running_task_type = TaskType::NONE;
 
   void process_task_queue();
@@ -66,10 +83,12 @@ class SECTouchComponent : public PollingComponent, public uart::UARTDevice {
    * Returns the index of the last byte stored in the buffer
    */
   int store_data_to_incoming_message(uint8_t data);
-  void cleanup_after_task_complete(bool failed = false);
+  void cleanup_after_task_complete(bool failed = false, bool is_timeout = false);
   void send_ack_message();
 
   unsigned long task_start_time_ = 0;
+  int current_running_task_property_id_ = -1;
+  bool last_scan_task_timed_out_ = false;
   void process_data_of_current_incoming_message();
 };
 }  // namespace sec_touch

--- a/components/sec_touch/sec_touch.h
+++ b/components/sec_touch/sec_touch.h
@@ -47,6 +47,8 @@ class SECTouchComponent : public PollingComponent, public uart::UARTDevice {
            this->manual_update_listeners.count(property_id) > 0;
   }
 
+  void set_inter_task_delay(uint32_t ms) { inter_task_delay_ms_ = ms; }
+
   void add_set_task(std::unique_ptr<SetDataTask> task);
   void add_recursive_tasks_to_get_queue();
   void add_manual_tasks_to_queue();
@@ -87,6 +89,8 @@ class SECTouchComponent : public PollingComponent, public uart::UARTDevice {
   void send_ack_message();
 
   unsigned long task_start_time_ = 0;
+  unsigned long task_ready_at_ms_ = 0;
+  uint32_t inter_task_delay_ms_ = 30;
   int current_running_task_property_id_ = -1;
   bool last_scan_task_timed_out_ = false;
   void process_data_of_current_incoming_message();

--- a/components/sec_touch_sniffer/sec_touch_sniffer.cpp
+++ b/components/sec_touch_sniffer/sec_touch_sniffer.cpp
@@ -1,0 +1,202 @@
+#include "sec_touch_sniffer.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace sec_touch {
+
+SecTouchSniffer::SecTouchSniffer(SECTouchComponent *parent) : parent_(parent) {}
+
+void SecTouchSniffer::setup() {
+  this->parent_->register_raw_message_listener([this](int command_id, int property_id, int new_value) {
+    this->on_raw_message_(command_id, property_id, new_value);
+  });
+
+  this->parent_->register_queue_empty_listener([this]() { this->on_queue_empty_(); });
+
+  this->update_scan_switch_();
+}
+
+void SecTouchSniffer::dump_config() {
+  ESP_LOGCONFIG(TAG, "SecTouchSniffer:");
+  ESP_LOGCONFIG(TAG, "  Time source: %s", this->time_ != nullptr ? "RTC" : "uptime fallback");
+  if (this->scan_end_ > 0) {
+    ESP_LOGCONFIG(TAG, "  Scan range: %d - %d", this->scan_start_, this->scan_end_);
+  } else {
+    ESP_LOGCONFIG(TAG, "  Scan: not configured (passive mode only)");
+  }
+}
+
+void SecTouchSniffer::update_scan_switch_() {
+  if (this->scan_switch_ != nullptr) {
+    this->scan_switch_->publish_state(this->is_scanning_);
+  }
+}
+
+void SecTouchSniffer::toggle_scan() {
+  if (this->is_scanning_) {
+    if (this->current_scan_id_ > this->scan_start_) {
+      ESP_LOGI(TAG, "Scan mode OFF — last queued ID: %d", this->current_scan_id_ - 1);
+    } else {
+      ESP_LOGI(TAG, "Scan mode OFF — no IDs were queued");
+    }
+    this->cancel_timeout("scan_retry");
+    this->cancel_timeout("scan_next");
+    this->scan_retry_pending_ = false;
+    this->is_scanning_ = false;
+    this->update_scan_switch_();
+    if (!this->discovered_ids_.empty()) {
+      this->publish_state(this->build_state_string_());
+    }
+    this->parent_->exit_scan_mode();
+    return;
+  }
+
+  if (this->scan_end_ == 0) {
+    ESP_LOGW(TAG, "toggle_scan() called but no scan range configured — ignoring");
+    return;
+  }
+
+  if (this->current_scan_id_ == 0 || this->current_scan_id_ > this->scan_end_) {
+    this->current_scan_id_ = this->scan_start_;
+  }
+
+  ESP_LOGI(TAG, "Scan mode ON — scanning IDs %d to %d (resuming from %d)", this->scan_start_, this->scan_end_,
+           this->current_scan_id_);
+  this->is_scanning_ = true;
+  this->update_scan_switch_();
+  this->parent_->enter_scan_mode();
+  // First task is submitted by on_queue_empty_() which fires immediately because
+  // enter_scan_mode() cleared the queue and reset the running task state
+}
+
+void SecTouchSniffer::on_queue_empty_() {
+  if (!this->is_scanning_) {
+    return;
+  }
+
+  if (this->parent_->get_last_scan_task_timed_out()) {
+    int failed_id = this->current_scan_id_ - 1;
+    if (this->scan_retry_pending_) {
+      ESP_LOGW(TAG, "Scan: property_id %d timed out again, skipping", failed_id);
+      this->scan_retry_pending_ = false;
+    } else {
+      ESP_LOGW(TAG, "Scan: property_id %d timed out, retrying in 5s", failed_id);
+      this->scan_retry_pending_ = true;
+      this->current_scan_id_--;
+      this->set_timeout("scan_retry", 5000, [this]() {
+        if (!this->is_scanning_) {
+          return;
+        }
+        ESP_LOGD(TAG, "Scan: queuing retry GET for property_id %d", this->current_scan_id_);
+        this->parent_->add_discovery_get_task(this->current_scan_id_++);
+      });
+      return;
+    }
+  } else {
+    this->scan_retry_pending_ = false;
+  }
+
+  while (this->current_scan_id_ <= this->scan_end_ &&
+         this->parent_->is_property_registered(this->current_scan_id_)) {
+    ESP_LOGI(TAG, "Scan: skipping registered property_id %d", this->current_scan_id_);
+    this->current_scan_id_++;
+  }
+
+  if (this->current_scan_id_ > this->scan_end_) {
+    ESP_LOGI(TAG, "Scan complete. %d unique IDs discovered.", this->discovered_ids_.size());
+    this->is_scanning_ = false;
+    this->update_scan_switch_();
+    this->publish_state(this->build_state_string_());
+    this->parent_->exit_scan_mode();
+    return;
+  }
+  int id_to_query = this->current_scan_id_++;
+  this->set_timeout("scan_next", 160, [this, id_to_query]() {
+    if (!this->is_scanning_) {
+      return;
+    }
+    ESP_LOGD(TAG, "Scan: queuing GET for property_id %d", id_to_query);
+    this->parent_->add_discovery_get_task(id_to_query);
+  });
+}
+
+void SecTouchSniffer::on_raw_message_(int command_id, int property_id, int new_value) {
+  auto it = this->discovered_ids_.find(property_id);
+  bool is_new = (it == this->discovered_ids_.end());
+  bool changed = is_new || (it->second.value != new_value || it->second.command_id != command_id);
+
+  if (!changed) {
+    return;
+  }
+
+  std::string ts = this->get_timestamp_();
+  SniffedEntry &entry = this->discovered_ids_[property_id];
+  entry.command_id = command_id;
+  entry.value = new_value;
+  std::strncpy(entry.last_seen_at, ts.c_str(), sizeof(entry.last_seen_at) - 1);
+  entry.last_seen_at[sizeof(entry.last_seen_at) - 1] = '\0';
+
+  if (is_new) {
+    ESP_LOGI(TAG, "NEW property_id %d (cmd=%d value=%d at=%s) total=%d", property_id, command_id, new_value, ts.c_str(),
+             this->discovered_ids_.size());
+  } else {
+    ESP_LOGD(TAG, "property_id %d updated (cmd=%d value=%d at=%s)", property_id, command_id, new_value, ts.c_str());
+  }
+
+  if (!this->is_scanning_) {
+    this->publish_state(this->build_state_string_());
+  }
+}
+
+std::string SecTouchSniffer::get_timestamp_() const {
+  if (this->time_ != nullptr) {
+    auto now = this->time_->now();
+    if (now.is_valid()) {
+      return now.strftime("%d-%m-%Y %H:%M");
+    }
+  }
+  char buf[16];
+  snprintf(buf, sizeof(buf), "t=%lus", millis() / 1000UL);
+  return std::string(buf);
+}
+
+std::string SecTouchSniffer::build_state_string_() const {
+  char buf[MAX_STATE_LEN + 4];  // +4 for worst-case ", ..." suffix during truncation
+  size_t pos = 0;
+  bool first = true;
+
+  for (const auto &kv : this->discovered_ids_) {
+    char entry[32];
+    int written = snprintf(entry, sizeof(entry), "%d=%d", kv.first, kv.second.value);
+    if (written <= 0 || written >= (int) sizeof(entry)) {
+      continue;
+    }
+    size_t entry_len = (size_t) written;
+    size_t sep_len = first ? 0 : 2;
+
+    if (pos + sep_len + entry_len + 3 > MAX_STATE_LEN) {
+      if (!first) {
+        memcpy(buf + pos, ", ", 2);
+        pos += 2;
+      }
+      memcpy(buf + pos, "...", 3);
+      pos += 3;
+      break;
+    }
+
+    if (!first) {
+      memcpy(buf + pos, ", ", 2);
+      pos += 2;
+    }
+    memcpy(buf + pos, entry, entry_len);
+    pos += entry_len;
+    first = false;
+  }
+
+  buf[pos] = '\0';
+  return std::string(buf, pos);
+}
+
+}  // namespace sec_touch
+}  // namespace esphome

--- a/components/sec_touch_sniffer/sec_touch_sniffer.cpp
+++ b/components/sec_touch_sniffer/sec_touch_sniffer.cpp
@@ -18,12 +18,18 @@ void SecTouchSniffer::setup() {
 }
 
 void SecTouchSniffer::dump_config() {
-  ESP_LOGCONFIG(TAG, "SecTouchSniffer:");
+  ESP_LOGCONFIG(TAG, "SEC-Touch-Sniffer:");
   ESP_LOGCONFIG(TAG, "  Time source: %s", this->time_ != nullptr ? "RTC" : "uptime fallback");
   if (this->scan_end_ > 0) {
     ESP_LOGCONFIG(TAG, "  Scan range: %d - %d", this->scan_start_, this->scan_end_);
   } else {
     ESP_LOGCONFIG(TAG, "  Scan: not configured (passive mode only)");
+  }
+  if (this->discovered_ids_.empty()) {
+    ESP_LOGCONFIG(TAG, "  Discovered IDs: none");
+  } else {
+    ESP_LOGCONFIG(TAG, "  Discovered IDs (%d): %s", (int) this->discovered_ids_.size(),
+                  this->build_state_string_().c_str());
   }
 }
 
@@ -97,8 +103,7 @@ void SecTouchSniffer::on_queue_empty_() {
     this->scan_retry_pending_ = false;
   }
 
-  while (this->current_scan_id_ <= this->scan_end_ &&
-         this->parent_->is_property_registered(this->current_scan_id_)) {
+  while (this->current_scan_id_ <= this->scan_end_ && this->parent_->is_property_registered(this->current_scan_id_)) {
     ESP_LOGI(TAG, "Scan: skipping registered property_id %d", this->current_scan_id_);
     this->current_scan_id_++;
   }

--- a/components/sec_touch_sniffer/sec_touch_sniffer.cpp
+++ b/components/sec_touch_sniffer/sec_touch_sniffer.cpp
@@ -60,6 +60,8 @@ void SecTouchSniffer::toggle_scan() {
 
   if (this->scan_end_ == 0) {
     ESP_LOGW(TAG, "toggle_scan() called but no scan range configured — ignoring");
+    this->is_scanning_ = false;
+    this->update_scan_switch_();
     return;
   }
 

--- a/components/sec_touch_sniffer/sec_touch_sniffer.h
+++ b/components/sec_touch_sniffer/sec_touch_sniffer.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <map>
+#include "esphome/core/component.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/components/time/real_time_clock.h"
+#include "../sec_touch/sec_touch.h"
+
+namespace esphome {
+namespace sec_touch {
+
+struct SniffedEntry {
+  int command_id;
+  int value;
+  char last_seen_at[20];  // "dd-mm-yyyy HH:MM" fits in 16 chars; fixed size avoids heap churn
+};
+
+class SecTouchSniffer : public Component, public text_sensor::TextSensor {
+  static constexpr const char *TAG = "SecTouchSniffer";
+  // Text sensor payload cap: keeps output within comfortable MQTT/API packet sizes.
+  // Each entry is ~35 chars; 255 chars fits ~7 entries before truncation.
+  static constexpr size_t MAX_STATE_LEN = 2048;
+
+ public:
+  explicit SecTouchSniffer(SECTouchComponent *parent);
+
+  void set_time(time::RealTimeClock *time) { this->time_ = time; }
+  void set_scan_range(int start, int end) {
+    this->scan_start_ = start;
+    this->scan_end_ = end;
+  }
+  void set_scan_switch(switch_::Switch *s) { this->scan_switch_ = s; }
+
+  bool is_scanning() const { return this->is_scanning_; }
+  void toggle_scan();
+
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  SECTouchComponent *parent_;
+  time::RealTimeClock *time_{nullptr};
+  switch_::Switch *scan_switch_{nullptr};
+
+  // Active scan not recommended on ESP8266 — each entry takes ~80-100 bytes;
+  // a 200-ID scan uses ~20 KB against only ~40 KB usable heap.
+  std::map<int, SniffedEntry> discovered_ids_;
+
+  int scan_start_{1};
+  int scan_end_{0};
+  int current_scan_id_{0};
+  bool is_scanning_{false};
+  bool scan_retry_pending_{false};
+
+  void update_scan_switch_();
+  void on_raw_message_(int command_id, int property_id, int new_value);
+  void on_queue_empty_();
+  std::string get_timestamp_() const;
+  std::string build_state_string_() const;
+};
+
+}  // namespace sec_touch
+}  // namespace esphome

--- a/components/sec_touch_sniffer/sec_touch_sniffer.h
+++ b/components/sec_touch_sniffer/sec_touch_sniffer.h
@@ -19,7 +19,7 @@ struct SniffedEntry {
 class SecTouchSniffer : public Component, public text_sensor::TextSensor {
   static constexpr const char *TAG = "SecTouchSniffer";
   // Text sensor payload cap: keeps output within comfortable MQTT/API packet sizes.
-  // Each entry is ~35 chars; 255 chars fits ~7 entries before truncation.
+  // Each entry is ~35 chars; 2048 chars fits ~58 entries before truncation.
   static constexpr size_t MAX_STATE_LEN = 2048;
 
  public:

--- a/components/sec_touch_sniffer/sec_touch_sniffer_scan_switch.h
+++ b/components/sec_touch_sniffer/sec_touch_sniffer_scan_switch.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/components/switch/switch.h"
+#include "esphome/core/helpers.h"
+#include "sec_touch_sniffer.h"
+
+namespace esphome {
+namespace sec_touch {
+
+class SecTouchSnifferScanSwitch : public switch_::Switch, public Parented<SecTouchSniffer> {
+ public:
+  SecTouchSnifferScanSwitch() = default;
+
+ protected:
+  void write_state(bool state) override {
+    if (state != this->parent_->is_scanning()) {
+      this->parent_->toggle_scan();
+    }
+  }
+};
+
+}  // namespace sec_touch
+}  // namespace esphome

--- a/components/sec_touch_sniffer/text_sensor.py
+++ b/components/sec_touch_sniffer/text_sensor.py
@@ -1,0 +1,67 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor, switch
+from esphome.components.time import RealTimeClock
+from esphome.const import CONF_ID, CONF_TIME_ID
+
+from esphome.components.sec_touch import CONF_SEC_TOUCH_ID, sec_touch_ns, SECTouchComponent
+
+DEPENDENCIES = ["sec_touch"]
+AUTO_LOAD = ["switch"]
+
+CONF_SCAN_START = "scan_start"
+CONF_SCAN_END = "scan_end"
+CONF_SCAN_SWITCH = "scan_switch"
+
+SecTouchSniffer = sec_touch_ns.class_(
+    "SecTouchSniffer", cg.Component, text_sensor.TextSensor
+)
+SecTouchSnifferScanSwitch = sec_touch_ns.class_(
+    "SecTouchSnifferScanSwitch", switch.Switch
+)
+
+
+def _validate_scan_range(config):
+    if config.get(CONF_SCAN_END, 0) > 0:
+        if config[CONF_SCAN_START] > config[CONF_SCAN_END]:
+            raise cv.Invalid(
+                f"scan_start ({config[CONF_SCAN_START]}) must be <= scan_end ({config[CONF_SCAN_END]})"
+            )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    text_sensor.text_sensor_schema(SecTouchSniffer)
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(SecTouchSniffer),
+            cv.Required(CONF_SEC_TOUCH_ID): cv.use_id(SECTouchComponent),
+            cv.Optional(CONF_TIME_ID): cv.use_id(RealTimeClock),
+            cv.Optional(CONF_SCAN_START, default=1): cv.positive_int,
+            cv.Optional(CONF_SCAN_END, default=0): cv.int_range(min=0),
+            cv.Optional(CONF_SCAN_SWITCH): switch.switch_schema(SecTouchSnifferScanSwitch),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA),
+    _validate_scan_range,
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_SEC_TOUCH_ID])
+    var = cg.new_Pvariable(config[CONF_ID], parent)
+    await cg.register_component(var, config)
+    await text_sensor.register_text_sensor(var, config)
+
+    if CONF_TIME_ID in config:
+        time_var = await cg.get_variable(config[CONF_TIME_ID])
+        cg.add(var.set_time(time_var))
+
+    scan_end = config[CONF_SCAN_END]
+    if scan_end > 0:
+        cg.add(var.set_scan_range(config[CONF_SCAN_START], scan_end))
+
+    if CONF_SCAN_SWITCH in config:
+        sw = await switch.new_switch(config[CONF_SCAN_SWITCH])
+        await cg.register_parented(sw, var)
+        cg.add(var.set_scan_switch(sw))


### PR DESCRIPTION
## Summary

Adds a new `sec_touch_sniffer` component for discovering unknown property IDs on the SEC hardware bus, and changes how user-triggered SET tasks are scheduled in the task queue so they are no longer delayed behind pending GET polls.

### Sniffer component (`components/sec_touch_sniffer/`)

A standalone ESPHome component that attaches to `sec_touch` and operates in two modes:

**Passive capture** — any message arriving for a property ID that no registered component has claimed is silently recorded (property ID, command type, last value, timestamp). Existing fan controls and listeners are unaffected.

**Active scan mode** — toggled via a switch entity. While active, regular polling is suspended and the sniffer iterates through a configurable range of property IDs, querying them one at a time and waiting for a response or timeout before moving to the next. Property IDs with registered listeners are skipped. Turning scan mode off resumes normal polling immediately and saves the last scanned position so the next activation can continue from where it left off.

Results are exposed as text sensor entities and a scan-mode switch in Home Assistant.

### SET task prioritization (`sec_touch.cpp`)

Previously all tasks — both periodic GET polls and user SET requests — were appended to the back of `data_task_queue`, meaning a fan speed change from Home Assistant could sit behind a full batch of polling tasks.

`add_set_task()` now inserts incoming SET tasks after any already-queued SET tasks and before the first GET task. User actions are dispatched as soon as the current in-flight task completes. Multiple rapid changes all land at the front in submission order and are processed before any GET resumes. The dispatch loop, watchdog, and cleanup logic are unchanged.

### Supporting changes

- `sec_touch` core: added intertask delay enforcement, improved watchdog and error log messages with task context, fixed GET/SET ACK handling distinction, added queue-empty listener registration.
- `_definitions.h`: extended task and enum definitions to support the sniffer.
- `readme.md`: full component documentation added.
- `CLAUDE.md`: project development guidelines added.
- `.specs/sniffer.md`: behaviour specification for the sniffer.